### PR TITLE
fix(principalResourceIds): ensure normalizer result is array

### DIFF
--- a/src/internals/action-creator/thunk/generateActionCreator.js
+++ b/src/internals/action-creator/thunk/generateActionCreator.js
@@ -59,12 +59,16 @@ const generateActionCreator = (
         )
       : { entities: data };
 
+    const principalResourceIdsArray = Array.isArray(principalResourceIds)
+      ? principalResourceIds
+      : [principalResourceIds];
+
     dispatch(
       actionCreatorActions.RECEIVE(
         normalizedURL,
         resourceId,
         normalizedPayload,
-        principalResourceIds,
+        principalResourceIdsArray,
       ),
     );
 


### PR DESCRIPTION
When normalizer's result is made of one entity, it was not an array.
Fixed it to ensure it is always an array an avoid inconsistency in store