### PR TITLE
fix(initializeNetworkHelpers): runtime error when specifying getToken

### DIFF
--- a/src/internals/action-creator/thunk/generateActionCreator.js
+++ b/src/internals/action-creator/thunk/generateActionCreator.js
@@ -23,11 +23,6 @@ const generateActionCreator = (
     ...getNetworkHelpers(),
     ...(networkHelpers || {}),
   };
-  const {
-    [`request${method}`]: requestMethod,
-    handleError,
-    handleStatusCode,
-  } = combinedNetworkHelpers;
 
   dispatch(actionCreatorActions.REQUEST(normalizedURL, resourceId));
 
@@ -42,8 +37,11 @@ const generateActionCreator = (
     );
     const finalBody = beforeHookReturn || body;
 
-    const res = await fetch(formattedURL, requestMethod(finalBody));
-    handleStatusCode(res);
+    const res = await fetch(
+      formattedURL,
+      combinedNetworkHelpers[`request${method}`](finalBody),
+    );
+    combinedNetworkHelpers.handleStatusCode(res);
     const data = res.status !== 204 ? await res.json() : {};
     const {
       entities: normalizedPayload,
@@ -86,7 +84,7 @@ const generateActionCreator = (
   } catch (error) {
     dispatch(actionCreatorActions.FAIL(normalizedURL, resourceId));
 
-    handleError(error, dispatch);
+    combinedNetworkHelpers.handleError(error, dispatch);
     safeCall(onError, error);
     return { error };
   }


### PR DESCRIPTION
Fixed runtime error `this.getToken()` is undefined, which happened
when overriding the built-in method

Fixes #26 