### PR TITLE
feat(persistence): additional options

### DIFF
--- a/docs/api/getPersistableState.md
+++ b/docs/api/getPersistableState.md
@@ -1,10 +1,14 @@
-# `getPersistableState(state)`
+# `getPersistableState(state, options)`
 
 Returns a state pruned from outdated data. [Read more](../principles/persistence.md) about what is removed from the state exactly.
 
 #### Arguments
 
-1.  (_state_): The current Redux state
+1.  (_state_): (`object`) The current Redux state
+2.  (_persistOptions_): (`object`) An object containing additional, optional options for the pruning:
+
+A. (_alwaysPersist_): (`string || array<string>`) String or array of strings containing resource name(s). Request performing on the resource(s) will **always** be persisted, expired or not
+B. (_neverPersist_): (`string || array<string>`) String or array of strings containing resource name(s). Request performing on the resource(s) will **never** be persisted, expired or not
 
 #### Returns
 
@@ -23,9 +27,16 @@ import thunkMiddleware from 'redux-thunk';
 // No need to manually install redux-persist if you already have installed redux-offline
 import { createTransform } from 'redux-persist';
 
-const restEasyTransform = createTransform(getPersistableState, null, {
-  whitelist: ['restEasy'],
-});
+const restEasyTransform = createTransform(
+  state =>
+    getPersistableState(state, {
+      persist: { alwaysPersist: ['tokens'], neverPersist: ['configuration'] },
+    }),
+  null,
+  {
+    whitelist: ['restEasy'],
+  },
+);
 
 const createPersistedStore = (persistCallback, initialStore = {}) => {
   const offlineCustomConfig = {
@@ -46,3 +57,8 @@ const createPersistedStore = (persistCallback, initialStore = {}) => {
 
 export default createPersistedStore;
 ```
+
+#### Tips
+
+* `persistOptions.alwaysPersist` is a great way to persist resources you would never want to expire
+* `persistOptions.neverPersist` is a great way to clear some resources each time your app starts

--- a/docs/principles/persistence.md
+++ b/docs/principles/persistence.md
@@ -4,7 +4,10 @@ Redux-rest-easy works out-of-the-box with libraries such as [redux-offline](http
 
 Here is a list of actions performed when you call [getPersistableState](../api/getPersistableState.md):
 
-* in-progress, expired and invalidated requests are deleted
-* requests with `expireAt` set to `never` (`cacheLifetime` set to `Infinity`) are invalidated
-* resources which are no longer referenced by any request are deleted
-* resolversHashes which refer to no longer existing requests or modified resources are deleted
+* In-progress requests are deleted. _This is to avoid pending requests never resolving._
+* Expired and invalidated requests are deleted. _This is to avoid keeping outdated requests possibly forever._
+* Requests with `expireAt` set to `never` (`cacheLifetime` set to `Infinity`) are invalidated. _This is to avoid trusting remote data forever. Can still be done via persistOptions.alwaysPersist_
+* Resources which are no longer referenced by any request are deleted. _This is to avoidkeeping outdated resources in the state._
+* resolversHashes which refer to no longer existing requests or modified resources are deleted. _This is to avoidkeeping outdated hashes in the state._
+
+The first action is mandatory to avoid inconsistent state, but the others won't be applied to requests performing on resources defined in `persistOptions.alwaysPersist` and `persistOptions.neverPersist`. Instead, such requests will always/never be persisted.

--- a/src/getPersistableState.js
+++ b/src/getPersistableState.js
@@ -1,5 +1,6 @@
 import getPrunedForPersistenceState from './internals/persistence/getPrunedForPersistenceState';
 
-const getPersistableState = state => getPrunedForPersistenceState(state);
+const getPersistableState = (state, persistOptions) =>
+  getPrunedForPersistenceState(state, persistOptions);
 
 export default getPersistableState;


### PR DESCRIPTION
Allow to always or never persist requests based on resourceNames. Available via persistOptions.alwaysPersist and persistOptions.neverPersist