### PR TITLE
fix(getPrunedForPersistenceState): conflicting requests

### DIFF
--- a/src/internals/persistence/getPrunedForPersistenceState.js
+++ b/src/internals/persistence/getPrunedForPersistenceState.js
@@ -55,6 +55,7 @@ const getPrunedForPersistenceState = (
         (requestResources, [resourceName, resourceIds]) => ({
           ...requestResources,
           [resourceName]: [
+            ...(allResources[resourceName] || []),
             ...(requestResources[resourceName] || []),
             ...resourceIds.map(id => id.toString()),
           ],


### PR DESCRIPTION
Fix persistence of state when several requests contain the same resource